### PR TITLE
Fix: BLE Onboarding, cJSON incorrect cert length

### DIFF
--- a/ezlopi-services/ezlopi-service-ble/ezlopi_service_ble_provisioning.c
+++ b/ezlopi-services/ezlopi-service-ble/ezlopi_service_ble_provisioning.c
@@ -489,7 +489,7 @@ static char *__base64_decode_provisioning_info(uint32_t total_size)
 
         uint32_t buffer_len = 0;
         decoded_config_json = ezlopi_malloc(__FUNCTION__, total_size);
-        // decoded_config_json = ezlopi_core_buffer_acquire(__FUNCTION__, &buffer_len, 5000);
+        decoded_config_json = ezlopi_core_buffer_acquire(__FUNCTION__, &buffer_len, 5000);
 
         if (decoded_config_json)
         {


### PR DESCRIPTION
## Description:

- Fix buffer acquire issue for base64 decoding while BLE onboarding.
- Add a method to replace enter escape sequence string (2 characters) to '\n'.
- Add alternate function to get the correct certificate length as cJSON was giving wrong length.

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with EzloPi core
  - [ ] I accept the [CLA](https://github.com/ezloteam/Ezlo_Pi/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla).